### PR TITLE
added clear feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,14 @@ const common = require ('./common');
 const { Sync } = require ('./Sync');
 
 logger.useDefaults();
-
+const args = process.argv.slice(2);
 const cfg = config.readConfig();
-
 const synctron = new Sync(cfg, logger);
 
-synctron.run();
-
+switch (args[0]) {
+  case '--clear':
+    synctron.clear()
+    break;
+  default:
+    synctron.run();
+}


### PR DESCRIPTION
`snipsync --clear` will remove anything between the snip target wrappers so that testing locally is easy 