### PR TITLE
Support per-snip features config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ Any text inside of the placeholders will be replaced by the code snippet when th
 The tool will automatically specify the code type for markdown rendering.
 For example, if the source file ends in ".go" then the code section will be written like this: ` ```go `
 
+#### Per-snip features
+
+In order to customize how a single snip is rendered, put a custom feature configuration as JSON in the snip start line.
+
+```md
+<!--SNIPSTART hellouniverse {"enable_source_link": false}-->
+<!--SNIPEND-->
+```
+
 ## Run
 
 From the root directory of your project run the following command:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snipsync",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",
   "repository": "git@github.com:temporalio/snippetsync.git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "readdirp": "^3.4.0",
     "rimraf": "^3.0.2"
   },
+  "files": ["index.js", "src"],
   "bin": {
     "snipsync": "index.js"
   },

--- a/src/common.js
+++ b/src/common.js
@@ -9,6 +9,5 @@ module.exports = {
   writeStart: '<!--SNIPSTART',
   writeStartClose: '-->',
   writeEnd: '<!--SNIPEND',
-  writeEndClose: '-->',
   fmtProgressBar: (message) => `⭐ + | {bar} | {percentage}% | {value}/{total} chunks | ${message}`,
 };

--- a/src/common.js
+++ b/src/common.js
@@ -7,6 +7,8 @@ module.exports = {
   readStart: '@@@SNIPSTART',
   readEnd: '@@@SNIPEND',
   writeStart: '<!--SNIPSTART',
+  writeStartClose: '-->',
   writeEnd: '<!--SNIPEND',
+  writeEndClose: '-->',
   fmtProgressBar: (message) => `⭐ + | {bar} | {percentage}% | {value}/{total} chunks | ${message}`,
 };


### PR DESCRIPTION
## What was changed:
Support for per-snip features config for combining snips with `enable_source_link` in the same config. 
## Why?
This will come in handy for the NodeJS docs.

## Checklist

1. How was this tested:
Ran locally and check the generated docs.

2. Any docs updates needed?
Updated the README.
