### PR TITLE
make unnecessarily async functions sync

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -114,7 +114,7 @@ class Sync {
     // Create an object for each file in the target directory
     const files = await this.getTargetFiles(insertFP);
     // Splice the snippets in the file objects
-    const filesToWrite = await this.spliceSnippets(snippets, files);
+    const filesToWrite = this.spliceSnippets(snippets, files);
     // Overwrite the files to the target directory
     await this.writeFiles(filesToWrite);
     // Delete the sync_repos directory
@@ -301,14 +301,14 @@ class Sync {
     for (const snippet of snippets) {
       spliceProgress.increment();
       for (let file of files) {
-        file = await this.getSplicedFile(snippet, file);
+        file = this.getSplicedFile(snippet, file);
       }
     }
     spliceProgress.stop();
     return files;
   }
   // getSplicedFile returns the the spliced file
-  async getSplicedFile(snippet, file) {
+  getSplicedFile(snippet, file) {
     const staticFile = file;
     let dynamicFile = file;
     let fileLineNumber = 1;
@@ -326,7 +326,7 @@ class Sync {
         }
       }
       if (line.includes(writeEnd) && lookForStop) {
-        dynamicFile = await this.spliceFile(
+        dynamicFile = this.spliceFile(
           spliceStart,
           fileLineNumber,
           snippet,
@@ -340,7 +340,7 @@ class Sync {
     return dynamicFile;
   }
   // spliceFile merges an individual snippet into the file
-  async spliceFile(start, end, snippet, file, config) {
+  spliceFile(start, end, snippet, file, config) {
     const rmlines = end - start;
     file.lines.splice(start, rmlines - 1, ...snippet.fmt(config.enable_source_link));
     return file;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:

There's some async functions that don't need to be async, figured I'd suggest changing that unless there's a reason to make them async.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:

Ran locally

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
