### PR TITLE
Per snip code block customization feature/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The `origins` property is a list of objects that have one of the following 2 for
 
 If the `ref` key is left blank or not specified, then the most recent commit from the master branch will be used.
 If the `enable_source_link` key in `features` is not specified, then it will default to `true`.
+If the `enable_code_block` key in `features` is not specified, then it will default to `true`.
 
 Example of a complete snipsync.config.yaml:
 
@@ -48,6 +49,7 @@ targets:
 
 features:
   enable_source_link: false
+  enable_code_block: false
 ```
 
 Example of a bare minimum snipsync.config.yaml:
@@ -96,10 +98,10 @@ For example, if the source file ends in ".go" then the code section will be writ
 
 #### Per-snip features
 
-In order to customize how a single snip is rendered, put a custom feature configuration as JSON in the snip start line.
+To customize how a single snip is rendered, add a JSON feature configuration in the snip start line.
 
 ```md
-<!--SNIPSTART hellouniverse {"enable_source_link": false}-->
+<!--SNIPSTART hellouniverse {"enable_source_link": false, "enable_code_block": false}-->
 <!--SNIPEND-->
 ```
 

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -441,16 +441,12 @@ function extractWriteIDAndConfig(line) {
 // overwriteConfig uses values if provided in the snippet placeholder
 function overwriteConfig(current, extracted) {
   let config = {};
-  if(extracted?.enable_source_link ?? true) {
-    config.enable_source_link = current.enable_source_link;
-  } else {
-    config.enable_source_link = extracted.enable_source_link;
-  }
-  if (extracted?.enable_code_block ?? true) {
-      config.enable_code_block = current.enable_code_block;
-  } else {
-    config.enable_code_block = extracted.enable_code_block;
-  }
+
+  config.enable_source_link = (extracted?.enable_source_link ?? true) ?
+    current.enable_source_link : extracted.enable_source_link;
+
+  config.enable_code_block = (extracted?.enable_code_block ?? true) ?
+    current.enable_code_block : extracted.enable_code_block;
 
   return config;
 }

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -355,8 +355,6 @@ class Sync {
   // spliceFile merges an individual snippet into the file
   async spliceFile(start, end, snippet, file, config) {
     const rmlines = end - start;
-    console.log("------------");
-    console.log(config)
     file.lines.splice(start, rmlines - 1, ...snippet.fmt(config));
     return file;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -7,10 +7,15 @@ module.exports.readConfig = (logger) => {
   logger.info(`loading configuration from ${cfgPath}`);
   const cfg = sync(cfgPath);
 
-  //Enable source link is set to true if it isn't specified in the config
+  // Enable source links if not specified in the config
   if (cfg?.features?.enable_source_link ?? true) {
     cfg['features'] = {};
     cfg['features']['enable_source_link'] = true;
+  }
+
+  // Enable code blocks if not specified in the config
+  if (cfg?.features?.enable_code_block ?? true) {
+    cfg['features']['enable_code_block'] = true;
   }
 
   return cfg;


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

New configuration was added to allow users to enable or disable code blocks, i.e backticks.
Extended it to be a per snip feature as well.

## Why?
<!-- Tell your future self why have you made these changes -->

Use case is for pulling in non-code examples, such as README content.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Locally -

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
      
Updated README
