### PR TITLE
fix octokit warning

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -226,7 +226,7 @@ class Sync {
   }
   // getArchive gets the Github repo archive from Github
   async getArchive(owner, repo, ref) {
-    const result = await this.github.repos.downloadArchive({
+    const result = await this.github.repos.downloadZipballArchive({
       owner,
       repo,
       ref,


### PR DESCRIPTION

## What was changed
renamed `downloadArchive` to `downloadZipballArchive`

## Why?
octokit was printing warnings for us

<img width="775" alt="CleanShot 2021-08-03 at 22 12 07@2x" src="https://user-images.githubusercontent.com/6764957/128125566-e4c3cc70-c099-4911-998e-3f96f5df7309.png">

https://app.netlify.com/sites/mystifying-fermi-1bc096/deploys/610a20f5decf420007153178