### PR TITLE
Add dedent option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If the `enable_code_block` key in `features` is not specified, then it will defa
 The `allowed_target_extensions` key in `features` lets you set a list of extensions to scan. Specify extensions like `[.md,.txt]`.
 If the `allowed_target_extensions` key in `features` is not specified, then it defaults to an empty array (`[]`) and all files are scanned. 
 
+The `enable_code_dedenting` key in `features` lets you remove leading spaces from indented code snippets. This is handy when you're including a snippet of code within a class or function and don't want to include the leading indentation. This is `false` by default. 
 
 Example of a complete `snipsync.config.yaml`:
 
@@ -55,6 +56,7 @@ features:
   enable_source_link: false
   enable_code_block: false
   allowed_target_extensions: [.md]
+  enable_code_dedenting: false
 ```
 
 Example of a bare minimum snipsync.config.yaml:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "anzip": "^0.2.0",
     "arraybuffer-to-buffer": "^0.0.7",
     "cli-progress": "^3.8.2",
+    "dedent": "^0.7.0",
     "glob": "^7.1.6",
     "js-logger": "^1.6.1",
     "line-reader": "^0.4.0",

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -4,6 +4,7 @@ const { promisify } = require('util');
 const { eachLine } = require('line-reader');
 const { fmtStartCodeBlock, markdownCodeTicks,extractionDir, fmtProgressBar, readStart, readEnd, rootDir, writeStart, writeStartClose, writeEnd } = require('./common');
 const { writeFile, unlink } = require('fs');
+const dedent = require('dedent');
 const path = require('path');
 const arrayBuffToBuff = require('arraybuffer-to-buffer');
 const anzip = require('anzip');
@@ -97,8 +98,14 @@ class File {
     this.lines = [];
   }
   // fileString converts the array of lines into a string
-  fileString() {
-    return `${this.lines.join("\n")}\n`;
+  fileString(dedentCode=false) {
+    let lines =  `${this.lines.join("\n")}\n`;
+
+    if(dedentCode){
+      lines = dedent(lines);
+    }
+
+    return lines;
   }
 }
 class ProgressBar {
@@ -395,7 +402,7 @@ class Sync {
     this.progress.updateOperation('writing updated files');
     this.progress.updateTotal(files.length);
     for (const file of files) {
-      await writeAsync(file.fullpath, file.fileString());
+      await writeAsync(file.fullpath, file.fileString(this.config.features.enable_code_dedenting));
       this.progress.increment();
     }
     return;

--- a/src/config.js
+++ b/src/config.js
@@ -29,5 +29,10 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['allowed_target_extensions'] = [];
   }
 
+  // Disable code block dedenting by default if not specified
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'enable_code_dedenting')) {
+    cfg['features']['enable_code_dedenting'] = false;
+  }
+
   return cfg;
 };

--- a/test/fixtures/tutorials/dedent.md
+++ b/test/fixtures/tutorials/dedent.md
@@ -1,0 +1,2 @@
+<!--SNIPSTART typescript-ejson-worker -->
+<!--SNIPEND-->


### PR DESCRIPTION
## What was changed
Adds dedent option.

Code snippets that are indented will have the outer-most indentation stripped when they're included into documentation pages when the `enable_code_dedenting` option is set to `true`.

## Why?
When including code snippets that have a lot of leading indentation, the code snippets appear too far indented in docs pages.

## Checklist

1. Closes #40 

2. How was this tested:

Run `npm test`

3. Any docs updates needed?

This PR updates `README.md` to include the new option.