### PR TITLE
only add ellipsis if enabled

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -30,7 +30,7 @@ const writeAsync = promisify(writeFile);
 const unlinkAsync = promisify(unlink);
 const eachLineAsync = promisify(eachLine);
 const rimrafAsync = promisify(rimraf);
-const enable_ellipsis = false
+let enable_ellipsis = false;
 // Snippet class contains info and methods used for passing and formatting code snippets
 class Snippet {
   constructor(id, ext, owner, repo, ref, filePath) {

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -30,6 +30,7 @@ const writeAsync = promisify(writeFile);
 const unlinkAsync = promisify(unlink);
 const eachLineAsync = promisify(eachLine);
 const rimrafAsync = promisify(rimraf);
+const enable_ellipsis = false
 // Snippet class contains info and methods used for passing and formatting code snippets
 class Snippet {
   constructor(id, ext, owner, repo, ref, filePath) {
@@ -73,6 +74,9 @@ class Snippet {
 
     if (config.enable_code_block) {
       lines.push(markdownCodeTicks);
+    }
+    if (config.enable_ellipsis) {
+      enable_ellipsis = true;
     }
     return lines;
   }
@@ -559,7 +563,7 @@ function selectLines(selectNumbers, lines, fileExtension) {
       nums = [num - 1, num];
     }
 
-    if (nums[0] != 0 && config.enable_ellipsis) {
+    if (nums[0] != 0 && enable_ellipsis) {
       newLines.push(`${ellipsisComment}`);
     }
     const capture = lines.slice(nums[0], nums[1]);

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -559,7 +559,7 @@ function selectLines(selectNumbers, lines, fileExtension) {
       nums = [num - 1, num];
     }
 
-    if (nums[0] != 0) {
+    if (nums[0] != 0 && config.enable_ellipsis) {
       newLines.push(`${ellipsisComment}`);
     }
     const capture = lines.slice(nums[0], nums[1]);

--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,11 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['enable_code_block'] = true;
   }
 
+  // Enable ellipsis between snips
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'enable_ellipsis')) {
+    cfg['features']['enable_ellipsis'] = true;
+  }
+
   // If allowed_target_extensions option isn't set, set it to an empty array
   // which will ignore the option and include all files.
   if (!Object.prototype.hasOwnProperty.call(cfg.features, 'allowed_target_extensions')) {

--- a/test/fixtures/expected-select.md
+++ b/test/fixtures/expected-select.md
@@ -4,7 +4,6 @@ Text above snippet
 [workflow.go](https://github.com/temporalio/money-transfer-project-template-go/blob/main/workflow.go)
 ```go
 func MoneyTransfer(ctx workflow.Context, input PaymentDetails) (string, error) {
-// ...
 	// RetryPolicy specifies how to automatically handle retries if an Activity fails.
 	retrypolicy := &temporal.RetryPolicy{
 		InitialInterval:        time.Second,


### PR DESCRIPTION
Remove default behavior of adding `// ...` between snips, now only enabled by `enable_ellipsis` flag.