### PR TITLE
Update group name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This repository is maintained by the Temporal Education team
-*  @temporalio/education
+* @temporal-community/devrel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This repository is maintained by the Temporal Education team
+# This repository is maintained by the @temporal-community/devrel team
 * @temporal-community/devrel


### PR DESCRIPTION
I transferred this repo from the temporalio org to the temporal-community org. There is no Education team within the latter as there was in the former, but since this is a subset of @temporal-community/devrel, I updated the CODEOWNERS file to specify that as the owner in order to make the file valid following the transfer.