### PR TITLE
feat: support SNIPSYNC_LOCAL_REPOS for local repo sources

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -12,7 +12,7 @@ const {
   rootDir,
   writeMarkerStyles
 } = require("./common");
-const { writeFile, unlink } = require("fs");
+const { writeFile, unlink, existsSync } = require("fs");
 const path = require("path");
 const arrayBuffToBuff = require("arraybuffer-to-buffer");
 const anzip = require("anzip");
@@ -270,6 +270,35 @@ class Sync {
           throw new Error(`Invalid origin: ${JSON.stringify(origin)}`);
         }
         const { owner, repo, ref } = origin;
+        const localReposDir = process.env.SNIPSYNC_LOCAL_REPOS;
+        if (localReposDir) {
+          const candidates = [
+            join(localReposDir, `${owner}-${repo}`),
+            join(localReposDir, repo),
+          ];
+          const localPath = candidates.find((p) => existsSync(p));
+          if (localPath) {
+            console.log(`snipsync: using local repo ${localPath} for ${owner}/${repo}`);
+            const { execSync } = require("child_process");
+            const grepResult = execSync(
+              `grep -rl "${readStart}" . --include="*.go" --include="*.java" --include="*.py" --include="*.ts" --include="*.js" --include="*.cs" --include="*.yaml" --include="*.yml" --include="*.rb" --include="*.php" --include="*.sample" 2>/dev/null || true`,
+              { cwd: localPath, encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 }
+            );
+            const filePaths = grepResult.trim().split("\n").filter(Boolean).map((f) => ({
+              name: basename(f),
+              directory: join(localPath, dirname(f)),
+            }));
+            repositories.push({
+              rtype: 'local',
+              owner,
+              repo,
+              ref,
+              filePaths,
+            });
+            this.progress.increment();
+            return;
+          }
+        }
         const repository = new Repo('remote', owner, repo, ref);
         try {
           await retryWithExponentialBackoff(async () => {


### PR DESCRIPTION
## Summary

- When `SNIPSYNC_LOCAL_REPOS` is set to a directory path, snipsync checks for local clones before downloading from GitHub
- Looks for `<dir>/<repo>` or `<dir>/<owner>-<repo>` on disk
- Uses `grep` to find only files containing `@@@SNIPSTART` markers, so it stays fast even on large repos
- Falls back to remote download if no local clone is found
- No config file changes needed. The env var is per-developer, so it does not affect CI or other contributors

## Use case

When working with unmerged sample repo branches, snipsync reads whatever branch is checked out locally instead of requiring `ref:` overrides in `snipsync.config.yaml`.

## Test plan

- [ ] Run `SNIPSYNC_LOCAL_REPOS=/path/to/workspace npx snipsync` and verify local repos are used (logged to stdout)
- [ ] Verify repos not cloned locally still download from GitHub
- [ ] Verify snippet output matches remote-sourced output