### PR TITLE
fix: preserve the SNIPSTART marker's indentation when splicing

### DIFF
--- a/src/Sync.js
+++ b/src/Sync.js
@@ -23,7 +23,7 @@ const glob = require("glob");
 const { type } = require("os");
 
 // Deindenting dependencies
-const { deindentByCommonPrefix, SENSITIVE_INDENT_EXTS } = require("./deindent");
+const { deindentByCommonPrefix, indentBy, leadingWhitespace, SENSITIVE_INDENT_EXTS } = require("./deindent");
 
 // Convert dependency functions to return promises
 const writeAsync = promisify(writeFile);
@@ -470,7 +470,11 @@ class Sync {
   // spliceFile merges an individual snippet into the file
   async spliceFile(start, end, snippet, file, config) {
     const rmlines = end - start;
-    file.lines.splice(start, rmlines - 1, ...snippet.fmt(config));
+    // `start` is the 1-based line number of the SNIPSTART marker, so the marker
+    // itself lives at index start - 1. Match its indentation so the spliced
+    // block stays inside whatever Markdown or JSX block encloses the marker.
+    const indent = leadingWhitespace(file.lines[start - 1]);
+    file.lines.splice(start, rmlines - 1, ...indentBy(snippet.fmt(config), indent));
     return file;
   }
   // clearSnippets loops through target files to remove snippets

--- a/src/deindent.js
+++ b/src/deindent.js
@@ -32,6 +32,34 @@ function deindentByCommonPrefix(lines) {
   return lines.map(l => (l.startsWith(prefix) ? l.replace(re, "") : l));
 }
 
+// leadingWhitespace returns the tabs/spaces a line starts with, or "" for a
+// line that starts at column 0 (or for no line at all).
+function leadingWhitespace(line) {
+  return (line || "").match(/^[\t ]*/)[0];
+}
+
+// indentBy prefixes every non-blank line with the given indent. Blank lines are
+// left alone so we never introduce trailing whitespace.
+//
+// This exists because a SNIPSTART marker does not have to sit at column 0. In
+// Markdown it can be nested inside a list item, and in MDX it can be nested
+// inside a JSX element. Content written at column 0 under an indented marker
+// ends the enclosing block: a fenced code block dropped at column 0 inside a
+// list item closes the item, which at best renumbers the list and at worst
+// leaves a JSX tag unclosed and fails the build.
+function indentBy(lines, indent) {
+  if (!indent) {
+    return lines.slice();
+  }
+  return lines.map((l) => (l.trim().length === 0 ? l : indent + l));
+}
+
 const SENSITIVE_INDENT_EXTS = new Set(['make', 'mk', 'Makefile', 'diff']);
 
-module.exports = { commonIndentPrefix, deindentByCommonPrefix, SENSITIVE_INDENT_EXTS };
+module.exports = {
+  commonIndentPrefix,
+  deindentByCommonPrefix,
+  leadingWhitespace,
+  indentBy,
+  SENSITIVE_INDENT_EXTS,
+};

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -553,3 +553,113 @@ test('Splice warns and does not modify on mismatched end', async () => {
   // Cleanup spy
   warnSpy.mockRestore();
 });
+
+test('Spliced content inherits the indentation of the SNIPSTART marker', async () => {
+  const srcPath = `${testEnvPath}/indent-src.ts`;
+  fs.writeFileSync(srcPath, `// @@@SNIPSTART indent-demo
+const driver = new Driver({
+  bucket: 'my-bucket',
+});
+// @@@SNIPEND
+`);
+
+  // The marker is nested three spaces deep, as it is when it sits inside a
+  // numbered list item in a docs page.
+  const mdxPath = `${testEnvPath}/indented.mdx`;
+  fs.writeFileSync(mdxPath, `1. Create the driver:
+
+   <!--SNIPSTART indent-demo -->
+   <!--SNIPEND-->
+
+2. Next step.
+`);
+
+  cfg.origins = [
+    { files: { pattern: srcPath, owner: 'temporalio', repo: 'snipsync', ref: 'main' } },
+  ];
+  cfg.features.allowed_target_extensions = ['.mdx'];
+
+  const synctron = new Sync(cfg, logger);
+  await synctron.run();
+
+  const out = fs.readFileSync(mdxPath, 'utf8');
+  const lines = out.split('\n');
+
+  // Every non-blank line we wrote between the markers carries the marker's indent,
+  // so the code block stays inside list item 1 instead of terminating it.
+  const start = lines.findIndex((l) => l.includes('SNIPSTART indent-demo'));
+  const end = lines.findIndex((l) => l.includes('SNIPEND'));
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  const body = lines.slice(start + 1, end).filter((l) => l.trim().length > 0);
+  expect(body.length).toBeGreaterThan(0);
+  for (const line of body) {
+    expect(line.startsWith('   ')).toBe(true);
+  }
+
+  // The fence, the source link, and the code all made it in.
+  expect(out).toMatch(/^ {3}```ts$/m);
+  expect(out).toMatch(/^ {3}\[.*indent-src\.ts\]\(https:\/\/github\.com\//m);
+  expect(out).toMatch(/^ {3}const driver = new Driver\(\{$/m);
+
+  // Relative indentation inside the snippet survives.
+  expect(out).toMatch(/^ {5}bucket: 'my-bucket',$/m);
+
+  // No blank line picked up trailing whitespace.
+  expect(out).not.toMatch(/^ +$/m);
+});
+
+test('Column-zero markers are spliced without added indentation', async () => {
+  const srcPath = `${testEnvPath}/flush-src.ts`;
+  fs.writeFileSync(srcPath, `// @@@SNIPSTART flush-demo
+const n = 1;
+// @@@SNIPEND
+`);
+
+  const mdxPath = `${testEnvPath}/flush.mdx`;
+  fs.writeFileSync(mdxPath, `<!--SNIPSTART flush-demo -->
+<!--SNIPEND-->
+`);
+
+  cfg.origins = [
+    { files: { pattern: srcPath, owner: 'temporalio', repo: 'snipsync', ref: 'main' } },
+  ];
+  cfg.features.allowed_target_extensions = ['.mdx'];
+
+  const synctron = new Sync(cfg, logger);
+  await synctron.run();
+
+  const out = fs.readFileSync(mdxPath, 'utf8');
+  expect(out).toMatch(/^```ts$/m);
+  expect(out).toMatch(/^const n = 1;$/m);
+});
+
+test('Re-running is idempotent for an indented marker', async () => {
+  const srcPath = `${testEnvPath}/idem-src.ts`;
+  fs.writeFileSync(srcPath, `// @@@SNIPSTART idem-demo
+const n = 1;
+// @@@SNIPEND
+`);
+
+  const mdxPath = `${testEnvPath}/idem.mdx`;
+  fs.writeFileSync(mdxPath, `- item:
+
+  <!--SNIPSTART idem-demo -->
+  <!--SNIPEND-->
+`);
+
+  cfg.origins = [
+    { files: { pattern: srcPath, owner: 'temporalio', repo: 'snipsync', ref: 'main' } },
+  ];
+  cfg.features.allowed_target_extensions = ['.mdx'];
+
+  await new Sync(cfg, logger).run();
+  const first = fs.readFileSync(mdxPath, 'utf8');
+
+  await new Sync(cfg, logger).run();
+  const second = fs.readFileSync(mdxPath, 'utf8');
+
+  expect(second).toEqual(first);
+  expect(first).toMatch(/^ {2}const n = 1;$/m);
+});


### PR DESCRIPTION
## What was changed

`spliceFile` wrote `snippet.fmt()` output verbatim, always starting at column 0. A SNIPSTART marker does not have to be at column 0 — in Markdown it can be nested inside a list item, and in MDX inside a JSX element. Writing at column 0 under an indented marker ends the enclosing block.

This re-applies the marker's own leading whitespace to every non-blank line written between the markers.

## Why

Two failure modes, one silent and one fatal.

**Silent:** in a plain Markdown list, a fenced code block at column 0 closes the list item. One `<ol>` becomes two. Numbering still looks right because the source keeps its literal ordinals (`2.` renders as `<ol start=2>`), so nobody noticed.

**Fatal:** in MDX, if a JSX element spans the marker, that element is never closed and compilation fails. On `temporalio/documentation` this surfaces as:

```
Error: MDX compilation failed for .../external-storage.mdx
Cause: Expected a closing tag for `<TabItem>` (70:6-70:52) before the end of `listItem`
```

Any page with `<Tabs>` inside a numbered procedure step hits this, which currently blocks wiring those pages to snipsync at all.

## Details

- Blank lines are left alone, so no trailing whitespace is introduced.
- Relative indentation inside the snippet is untouched; the existing dedent behavior is unchanged.
- Markers already at column 0 get an empty prefix, so **existing targets are byte-for-byte unchanged**. This is why the whole existing suite passes without fixture updates.

## How this was tested

Three new tests in `test/sync.test.js`: indented marker inherits indentation (fence, source link, code, and relative indent all checked, plus no trailing whitespace), column-zero marker is unaffected, and re-running is idempotent.

`npx jest` — 38/38 pass. `npx eslint . --ext .js` — 0 errors, same 12 pre-existing warnings as `main`.

Also verified end to end against the `temporalio/documentation` tree with real origins:

- the previously failing page builds, and its procedure renders as a single `<ol>` with tabs and both code blocks intact
- the Go and Python external storage pages go from `['<ol>', '<ol start=2>']` back to `['<ol>']`
- no markers leak into the rendered HTML

## Docs updates needed?

No. Behavior only changes for markers that are not at column 0, which previously could not be used reliably.